### PR TITLE
Fix a mistyped property

### DIFF
--- a/src/modules/Result.mjs
+++ b/src/modules/Result.mjs
@@ -37,7 +37,7 @@ export default class Result {
 		 * @desc True if B is completely contained within A
 		 * @type {Boolean}
 		 */
-		this.a_in_b = false;
+		this.b_in_a = false;
 
 		/**
 		 * @desc The magnitude of the shortest axis of overlap


### PR DESCRIPTION
## Description
Fix a small mistyped property in `Result.mjs` constructor